### PR TITLE
BRO-65: Non-Playable Track Tracker

### DIFF
--- a/src/Sanity_Tests.py
+++ b/src/Sanity_Tests.py
@@ -31,7 +31,9 @@ import logging
 import os
 import re
 import sqlite3
+
 from glob import glob
+from pprint import PrettyPrinter
 
 import General_Spotify_Helpers as gsh
 
@@ -256,12 +258,39 @@ class SanityTest(LogAllMethods):
                     res_list.append(f"__{playlist['name']} == {track['name']} - {artist_names}")
 
         return res_list
-            
-    # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════
-    # MISC  ═══════════════════════════════════════════════════════════════════════════════════════════════════════════
-    # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════
-    def print_the_results(self):
-        print("unimplemented")
 
+    """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+    DESCRIPTION: Goes through all of our tracks and lets us know if a track is no longer 'playable' by Spotify.
+    INPUT: NA
+    OUTPUT: List of tracks that cannot be currently played but are not local.
+    """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+    def sanity_playable_tracks(self) -> list[dict]:
+        res_list = []
+        
+        for track in self.master_playlist[0]['tracks']:
+            if not track['is_playable'] and not track['is_local']:
+                artist_names = [artist['name'] for artist in self.dbh.db_get_track_artists(track['id'])]
+                res_list.append(f"{track['name']} - {str(', '.join(artist_names))}")
+                
+        return res_list
+            
+    # ════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    # MISC  ══════════════════════════════════════════════════════════════════════════════════════════════════════════
+    # ════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    def run_suite(self) -> None:
+        pp = PrettyPrinter(width=150)
+        print("Playlist Collection Differences ========")
+        pp.pprint(self.sanity_diffs_in_major_playlist_sets())
+        print("Current In Progress Artists ============")
+        pp.pprint(self.sanity_in_progress_artists())
+        print("Duplicates =============================")
+        pp.pprint(self.sanity_duplicates())
+        print("Contributing Artists ===================")
+        pp.pprint(self.sanity_contributing_artists())
+        print("Artist Playlist Integrity ==============")
+        pp.pprint(self.sanity_artist_playlist_integrity())
+        print("Non-Playable Tracks ====================")
+        pp.pprint(self.sanity_playable_tracks())
+        
 
 # FIN ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════

--- a/src/Sanity_Tests.py
+++ b/src/Sanity_Tests.py
@@ -26,6 +26,10 @@
 #
 # In Progress Sanity Test -
 #   - Basically just give the user a list of __ playlists that the user is not following currently
+#
+# Non-Playable Tracks Sanity Test -
+#   - Based off of the 'preview_url' in a track but goal is to make sure every song in our main playlist is 'playable'
+#       since Spotify just 'grays' them out without notification.
 # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 import logging
 import os

--- a/src/Spotify_Features.py
+++ b/src/Spotify_Features.py
@@ -222,7 +222,7 @@ class SpotifyFeatures(LogAllMethods):
     """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''"""
     def generate_weekly_report(self) -> None:
         sanity_tester = SanityTest(logger=self.logger)
-        WeeklyReport(self.spotify, sanity_tester, logger=self.logger).gen_weekly_report()
+        WeeklyReport(sanity_tester, logger=self.logger).gen_weekly_report()
         
     """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''"""
     DESCRIPTION: Runs various santiy checks against the user's collection to verify nothing has been mismanaged.

--- a/src/Weekly_Report.py
+++ b/src/Weekly_Report.py
@@ -11,6 +11,10 @@
 # Current Reporting Functionality -
 # SANITY TESTS -
 #   All sanity tests under Sanity_Tests.py are currently being run and pushed to the user.
+#
+# LISTENING DATA -
+#   It generates a graph giving you how many hours you listened to each day over the past week. It also overlays a line
+#   graph that shows you your current average over the past 4 weeks.
 # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 import matplotlib.pyplot as plt 
 import os
@@ -32,20 +36,15 @@ from Log_Playback import LogPlayback
 DESCRIPTION: Class that handles creating a backup of the user's followed artists, playlists, and all their tracks.
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 class WeeklyReport(LogAllMethods):
-    FEATURE_SCOPES = []
-    
     SENDER_EMAIL = "jacobs.spotify.email@gmail.com"
     RECIPIENT_EMAIL = "jacob.leazott@gmail.com"
     EMAIL_TOKEN_LOCATION = "tokens/email_token.txt"
 
     db_conn = None
     
-    def __init__(self, spotify, sanity_tester, logger=None):
-        self.spotify = spotify
-        self.spotify.scopes = self.FEATURE_SCOPES
+    def __init__(self, sanity_tester, logger=None):
         self.sanity_tester = sanity_tester
         self.logger = logger if logger is not None else logging.getLogger()
-
 
     """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''"""
     DESCRIPTION: Sends an email with subject, and body to 'RECIPIENT_EMAIL' from 'SENDER_EMAIL', requires app creds from
@@ -193,11 +192,12 @@ class WeeklyReport(LogAllMethods):
                                             "No Issues Detected In Artist Integrity Good Job!")
         st_contr = self.gen_html_unordered_list(self.sanity_tester.sanity_contributing_artists(), 
                                             "No Missing Tracks From Contributing Artists Good Job!")
+        st_play = self.gen_html_unordered_list(self.sanity_tester.sanity_playable_tracks(), 
+                                            "All Tracks Are Playable, Great!")
         
         self.gen_playback_graph()
         
-        body = \
-        f"""
+        body = f"""
         <html>
             <h1> Weekly Spotify Report </h1>
             <h1> Weekly Listening Data </h1>
@@ -213,6 +213,8 @@ class WeeklyReport(LogAllMethods):
             <div style="margin-left:35px;"> {textwrap.indent(st_integ, "\t\t")} \n\t </div>
             <h2> - Contributing Artists Missing - </h2>
             <div style="margin-left:35px;"> {textwrap.indent(st_contr, "\t\t")} \n\t </div>
+            <h2> - Non-Playable Tracks - </h2>
+            <div style="margin-left:35px;"> {textwrap.indent(st_play, "\t\t")} \n\t </div>
         </html>
         """
         subject = f"Weekly Spotify Report - {datetime.today().strftime('%b %d %Y')}"


### PR DESCRIPTION
Spotify sometimes 'removes' tracks from their site. The track usually remains in the playlist but it is grayed out and is unplayable. I added a sanity check that goes through our main playlist and makes sure all of our tracks are playable. This way if a track gets removed we can go and grab it and add it to our local collection.