### PR TITLE
BRO-112: Changed Shuffle Macro To Use 'Repeat' Instead Of Specified Track

### DIFF
--- a/src/General_Spotify_Helpers.py
+++ b/src/General_Spotify_Helpers.py
@@ -309,13 +309,13 @@ class GeneralSpotifyHelpers:
     INPUT: play - True if play, False if pause.
            skip - "next" if skip track, "prev" if previous track.
            shuffle - True/ False if shuffle is enabled.
-           repeat - True/ False if repeat is enabled.
+           repeat - 'off', 'track', or 'context' for the state of repeat.
     OUTPUT: NA
     """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''""""""
     def change_playback(self, pause: Optional[bool]=None, 
                         skip: str="", 
                         shuffle: Optional[bool]=None, 
-                        repeat: Optional[bool]=None) -> None:
+                        repeat: str="") -> None:
         self._validate_scope(["user-modify-playback-state"])
         
         if pause == True:
@@ -329,7 +329,7 @@ class GeneralSpotifyHelpers:
         if shuffle != None:
             self.sp.shuffle(shuffle)
         
-        if repeat != None:
+        if repeat != "":
             self.sp.repeat(repeat)
 
     # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════

--- a/src/Implementations.py
+++ b/src/Implementations.py
@@ -107,14 +107,15 @@ def log_and_macro(spotify_features) -> None:
     
     # Only Trigger Macros If We Are Playing A Playlist
     if playback['context'] is not None and playback['context']['type'] == "playlist":
+        if playback['repeat_state'] != "off":
+            spotify_features.spotify.change_playback(repeat='off')
+            shuffle_type = ShuffleType.WEIGHTED if playback['shuffle_state'] else ShuffleType.RANDOM
+            startup_feature_thread(SpotifyFeatures.shuffle_playlist
+                                   , playback['context']['id']
+                                   , shuffle_type=shuffle_type
+                                   , log_file_name="Shuffle-Playlist.log")
+            
         match playback['track']['id']:
-            case Settings.SHUFFLE_MACRO_ID:
-                shuffle_type = ShuffleType.WEIGHTED if playback['shuffle_state'] else ShuffleType.RANDOM
-                startup_feature_thread(SpotifyFeatures.shuffle_playlist
-                                       , playback['context']['id']
-                                       , shuffle_type=shuffle_type
-                                       , log_file_name="Shuffle-Playlist.log")
-
             case Settings.GEN_ARTIST_MACRO_ID:
                 spotify_features.skip_track()
                 startup_feature_thread(SpotifyFeatures.generate_artist_playlist_from_playlist

--- a/src/features/Misc_Features.py
+++ b/src/features/Misc_Features.py
@@ -206,10 +206,9 @@ class MiscFeatures(LogAllMethods):
     """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''"""
     def update_daily_latest_playlist(self):
         # Grab # of tracks, subtracts PLAYLIST_LENGTH so we will always grab the right amount.
-        tracks = [Settings.SHUFFLE_MACRO_ID]
         offset = self.spotify.get_playlist_data(Settings.LATEST_SOURCE_PLAYLIST, info=[['tracks', 'total']])[0] \
                     - Settings.LATEST_PLAYLIST_LENGTH
-        tracks += [track['id'] for track in self.spotify.get_playlist_tracks(Settings.LATEST_SOURCE_PLAYLIST, 
+        tracks = [track['id'] for track in self.spotify.get_playlist_tracks(Settings.LATEST_SOURCE_PLAYLIST, 
                                                                              offset=offset)]
         
         remove_success = self.spotify.remove_all_playlist_tracks(Settings.LATEST_DEST_PLAYLIST, 

--- a/src/features/Sanity_Tests.py
+++ b/src/features/Sanity_Tests.py
@@ -100,8 +100,7 @@ class SanityTest(LogAllMethods):
 
         for track in tracks:
             # If track isn't local, already checked, not a double duplicate, and not our macros
-            if not track['is_local'] and track['id'] in checked_list and track not in duplicates \
-                    and track['id'] != Settings.SHUFFLE_MACRO_ID:
+            if not track['is_local'] and track['id'] in checked_list and track not in duplicates:
                 artist_names = [artist['name'] for artist in self.dbh.db_get_track_artists(track['id'])]
                 duplicates.append(f"{track['name']} -- {artist_names}")
             checked_list.append(track['id'])

--- a/src/helpers/Settings.py
+++ b/src/helpers/Settings.py
@@ -31,12 +31,10 @@ class SettingsClass:
     LOGGING_INTERVAL_S: int     = 15
     
     # Macro IDs
-    SHUFFLE_MACRO_ID: str             = "2DlsEWns58UPs5X7PXrPJI" # 'Meditation'
     GEN_ARTIST_MACRO_ID: str          = "24NFf8j4Hc21IxQK7POU6f" # 'Creating New Melodies'
     DISTRIBUTE_TRACKS_MACRO_ID: str   = "2gps7VcJwo6nVmAxb9X3y2" # 'distributing'
     ORGANIZE_PLAYLIST_MACRO_ID: str   = "7mmImiqGDVDjH17htwQPeO" # 'Let's Organize'
-    MACRO_LIST: tuple                 = (SHUFFLE_MACRO_ID, 
-                                         GEN_ARTIST_MACRO_ID, 
+    MACRO_LIST: tuple                 = (GEN_ARTIST_MACRO_ID, 
                                          DISTRIBUTE_TRACKS_MACRO_ID, 
                                          ORGANIZE_PLAYLIST_MACRO_ID)
     


### PR DESCRIPTION
Pretty useful update here to use the 'repeat' state from the spotify player instead of a random track. This allows us to shuffle any playlist (if we know the tracks of course).