### PR TITLE
BRO-126: Removed Skipping During Shuffle Macro

### DIFF
--- a/src/features/Shuffle_Styles.py
+++ b/src/features/Shuffle_Styles.py
@@ -130,7 +130,7 @@ class Shuffler(LogAllMethods):
         
         if len(track_ids) > 0:
             self.spotify.write_to_queue([track_ids[0]])
-            self.spotify.change_playback(skip="next", shuffle=True)
+            self.spotify.change_playback(shuffle=True)
             self.spotify.write_to_queue(track_ids[1:Settings.MAX_QUEUE_LENGTH])
 
 


### PR DESCRIPTION
This used to be "necessary" because of the macro track that we used, now it uses the repeat state so this is just more annoying than anything else.