### PR TITLE
BRO-130: Improved Error Handling

### DIFF
--- a/src/features/Shuffle_Styles.py
+++ b/src/features/Shuffle_Styles.py
@@ -20,7 +20,6 @@
 #               listens). It then 'randomizes' each 'group' of tracks ie. tracks with 1 listen in 1 group, 2 listens
 #               in another and so on. This way no track with say 3 listens ends up in the queue before one with 2.
 # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
-import atexit
 import logging
 import random
 import sqlite3

--- a/src/proxy/Spotify_Proxy_Server.py
+++ b/src/proxy/Spotify_Proxy_Server.py
@@ -24,7 +24,7 @@ from src.helpers.Settings   import Settings
 DESCRIPTION: Creates and manages a flask server as well as our spotipy instance. Handles token refreshing and allows 
                 us to have a consistant connection to the API.
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-class SpotifyServer():
+class SpotifyServer(LogAllMethods):
     
     def __init__(self):
         self.logger = get_file_logger(f'logs/Proxy-Server.log', log_level=logging.INFO, mode='a')

--- a/src/proxy/Spotipy_Proxy.py
+++ b/src/proxy/Spotipy_Proxy.py
@@ -10,6 +10,7 @@
 #   when in reality it is all passed through our proxy to our flask server that owns the object.
 # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 import logging
+import sys
 import time
 import requests
 
@@ -40,7 +41,7 @@ class SpotipyProxy:
                     # Check if the total time elapsed exceeds the overall timeout
                     elapsed_time = time.perf_counter() - start_time
                     if elapsed_time > self.overall_timeout:
-                        raise Exception(f"Operation timed out after {self.overall_timeout} seconds")
+                        raise TimeoutError(f"Operation timed out after {self.overall_timeout} seconds")
                     
                     # Make the request with a short timeout for each individual request
                     response = requests.post(url, json=payload, timeout=5)
@@ -57,7 +58,7 @@ class SpotipyProxy:
                     # Check if the total time exceeded the overall timeout before retrying
                     elapsed_time = time.perf_counter() - start_time
                     if elapsed_time > self.overall_timeout:
-                        raise Exception(f"Operation timed out after {self.overall_timeout} seconds")
+                        raise TimeoutError(f"Operation timed out after {self.overall_timeout} seconds")
                     
                     # Backoff and retry
                     delay = self.backoff_factor * (2 ** attempt)  # Exponential backoff
@@ -65,7 +66,7 @@ class SpotipyProxy:
                     time.sleep(delay)
                     
             self.logger.error(f"Request failed after {self.max_retries} attempts.")
-            raise Exception("Max retries exceeded.")
+            sys.exit(0)
 
         return method
 

--- a/src/proxy/Spotipy_Proxy.py
+++ b/src/proxy/Spotipy_Proxy.py
@@ -14,13 +14,14 @@ import sys
 import time
 import requests
 
-from src.helpers.Settings import Settings
+from src.helpers.decorators import *
+from src.helpers.Settings   import Settings
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 DESCRIPTION: Abstracted proxy for spotipy. This way all methods from spotipy can be called like we actually own the 
                 instance, when in reality it is all passed through our proxy to our flask server that owns the object.
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-class SpotipyProxy:
+class SpotipyProxy(LogAllMethods):
     
     def __init__(self, logger: logging.Logger=None, max_retries: int=3
                  , backoff_factor: float=1.0, overall_timeout: int=20) -> None:

--- a/tests/src/features/test_Backup_Spotify_Data.py
+++ b/tests/src/features/test_Backup_Spotify_Data.py
@@ -9,6 +9,7 @@
 # Unit tests for all functionality out of 'Backup_Spotify_Data.py'.
 # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 import sqlite3
+import uuid
 import unittest
 from unittest import mock
 
@@ -25,25 +26,31 @@ class TestBackupSpotifyData(unittest.TestCase):
     @mock.patch('src.General_Spotify_Helpers.SpotipyProxy', new=MockedSpotipyProxy)
     def setUp(self):
         self.spotify = gsh.GeneralSpotifyHelpers()
-        self.backup = BackupSpotifyData(self.spotify, db_path=":memory:")
+        self.unique_db_name = f"file:shared_memory_{uuid.uuid4()}?mode=memory&cache=shared"
+        self.conn = sqlite3.connect(self.unique_db_name, uri=True)
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self.backup = BackupSpotifyData(self.spotify, db_path=self.unique_db_name)
         self.backup._create_backup_data_db()
-
+    
+    def tearDown(self):
+        self.conn.close()
+    
     def test_replace_none(self):
         # Test replacing None values in a simple dictionary.
         input_data = {"key1": "value1", "key2": None, "key3": 123}
         expected_output = {"key1": "value1", "key2": "unknown", "key3": 123}
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test replacing None values in a simple list.
         input_data = [1, None, "value", None]
         expected_output = [1, "unknown", "value", "unknown"]
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test replacing None values in a nested dictionary.
         input_data = {"key1": {"subkey1": None, "subkey2": "value"}, "key2": 123}
         expected_output = {"key1": {"subkey1": "unknown", "subkey2": "value"}, "key2": 123}
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test replacing None values in a nested list.
         input_data = [1, [None, "value"], [None, 3]]
         expected_output = [1, ["unknown", "value"], ["unknown", 3]]
@@ -53,7 +60,7 @@ class TestBackupSpotifyData(unittest.TestCase):
         input_data = {"key1": [1, None, {"subkey1": None}], "key2": None}
         expected_output = {"key1": [1, "unknown", {"subkey1": "unknown"}], "key2": "unknown"}
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test when no None values are present.
         input_data = {"key1": "value", "key2": 123, "key3": [1, "two"]}
         expected_output = {"key1": "value", "key2": 123, "key3": [1, "two"]}
@@ -63,17 +70,17 @@ class TestBackupSpotifyData(unittest.TestCase):
         input_data = {}
         expected_output = {}
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test replacing None values in an empty list.
         input_data = []
         expected_output = []
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test when input is None.
         input_data = None
         expected_output = "unknown"
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+        
         # Test replacing None in a complex structure with nested dictionaries and lists.
         input_data = {
             "key1": [1, {"subkey1": None, "subkey2": [None, 2]}, None],
@@ -86,10 +93,10 @@ class TestBackupSpotifyData(unittest.TestCase):
             "key3": "unknown"
         }
         self.assertEqual(replace_none(input_data, "unknown"), expected_output)
-
+    
     def test_get_column_types(self):
         # Test for correct Python types for a table.
-        self.backup.db_conn.execute("""
+        self.conn.execute("""
             CREATE TABLE test_table (
                 id INTEGER PRIMARY KEY,
                 name TEXT,
@@ -97,20 +104,37 @@ class TestBackupSpotifyData(unittest.TestCase):
                 data BLOB,
                 value NUMERIC
             )""")
-        self.assertEqual(get_column_types(self.backup.db_conn, "test_table"), [int, str, float, bytes, float])
-    
+        self.conn.commit()
+        self.assertEqual(get_column_types(self.conn, "test_table"), [int, str, float, bytes, float])
+        
         # Test for a column with an unsupported SQLite type.
-        self.backup.db_conn.execute("""
+        self.conn.execute("""
             CREATE TABLE test_unsupported (
                 id INTEGER PRIMARY KEY,
                 custom_column CUSTOM_TYPE
             )""")
-        self.assertEqual(get_column_types(self.backup.db_conn, "test_unsupported"), [int, str])
-
-    def test__insert_many(self):
+        self.conn.commit()
+        self.assertEqual(get_column_types(self.conn, "test_unsupported"), [int, str])
+    
+    @mock.patch("sqlite3.connect")
+    def test_connect_db_success(self, mock_connect):
+        """Test that the context manager sets up the database connection properly."""
+        mock_conn = mock.MagicMock()
+        mock_connect.return_value = mock_conn
+        
+        with self.backup.connect_db() as conn:
+            conn.execute("SELECT 1")
+        
+        # Assertions
+        mock_connect.assert_called_once_with(self.unique_db_name)  # Ensures db connection was attempted
+        mock_conn.execute.assert_any_call("PRAGMA foreign_keys = ON;")  # Ensures PRAGMA was set
+        mock_conn.commit.assert_called_once()  # Ensures commit was called
+        mock_conn.close.assert_called_once()  # Ensures connection was closed
+    
+    def test_insert_many(self):
         # Test that inserting an empty list does nothing.
         self.backup._insert_many("artists", [])
-        self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM artists").fetchone()[0], 0)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM artists").fetchone()[0], 0)
         
         # Test inserting with inconsistent row lengths.
         with self.assertRaises(sqlite3.ProgrammingError):
@@ -127,72 +151,77 @@ class TestBackupSpotifyData(unittest.TestCase):
         # Test inserting data with fields that don't exist in the table.
         with self.assertRaises(sqlite3.OperationalError):
             self.backup._insert_many("artists", [("artist_1", "Artist One", "ExtraField")])
-            
+        
         # Test inserting data with foreign key that does not exist in the referenced table.
         with self.assertRaises(sqlite3.IntegrityError):
             self.backup._insert_many("albums_artists", [("album_1", "nonexistant_artist")])
         
         # Test inserting duplicate data.
         self.backup._insert_many("artists", [("artist_1", "Artist One")])
-        res = self.backup.db_conn.execute("SELECT COUNT(*) FROM artists WHERE id = ?", ("artist_1",)).fetchone()[0]
+        res = self.conn.execute("SELECT COUNT(*) FROM artists WHERE id = ?", ("artist_1",)).fetchone()[0]
         self.assertEqual(res, 1)
         
         # Attempt to insert duplicate data.
         self.backup._insert_many("artists", [("artist_1", "Artist Duplicate")])
-        res = self.backup.db_conn.execute("SELECT COUNT(*) FROM artists WHERE id = ?", ("artist_1",)).fetchone()[0]
+        res = self.conn.execute("SELECT COUNT(*) FROM artists WHERE id = ?", ("artist_1",)).fetchone()[0]
         self.assertEqual(res, 1)
         
         # Test batch_size with equal sets
         test_data = [(f"playlist_{i}", f"Playlist {i}", f"Desc {i}") for i in range(10)]
-        self.backup.db_conn.execute("DELETE FROM playlists")
+        self.conn.execute("DELETE FROM playlists")
+        self.conn.commit()
         self.backup._insert_many("playlists", test_data, batch_size=5)        
-        self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 10)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 10)
         # Test unequal batches
         test_data = [(f"playlist_{i}", f"Playlist {i}", f"Desc {i}") for i in range(17)]
-        self.backup.db_conn.execute("DELETE FROM playlists")
+        self.conn.execute("DELETE FROM playlists")
+        self.conn.commit()
         self.backup._insert_many("playlists", test_data, batch_size=5)        
-        self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 17)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 17)
         # Test inserting less than batch_size
         test_data = [(f"playlist_{i}", f"Playlist {i}", f"Desc {i}") for i in range(1)]
-        self.backup.db_conn.execute("DELETE FROM playlists")
+        self.conn.execute("DELETE FROM playlists")
+        self.conn.commit()
         self.backup._insert_many("playlists", test_data, batch_size=5)        
-        self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 1)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 1)
         # Test batch_size of 1
         test_data = [(f"playlist_{i}", f"Playlist {i}", f"Desc {i}") for i in range(4)]
-        self.backup.db_conn.execute("DELETE FROM playlists")
+        self.conn.execute("DELETE FROM playlists")
+        self.conn.commit()
         self.backup._insert_many("playlists", test_data, batch_size=1)        
-        self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 4)
+        self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 4)
         # Test batch_size of 0
         with self.assertRaises(ValueError):
             test_data = [(f"playlist_{i}", f"Playlist {i}", f"Desc {i}") for i in range(17)]
-            self.backup.db_conn.execute("DELETE FROM playlists")
+            self.conn.execute("DELETE FROM playlists")
+            self.conn.commit()
             self.backup._insert_many("playlists", test_data, batch_size=0)        
-            self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 17)
-
+            self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM playlists").fetchone()[0], 17)
+    
     def test_create_backup_data_db(self):
         # This method is just creating sqlite tables, nothing to unit test since we will fail the other unit tests if
         #   it is incorrect.
         assert True
-
+    
     def test_add_followed_artists_to_db(self):
         thelp.create_env(self.spotify)
         # Test basic insert/ duplicate
         for _ in range(2):
             self.backup._add_followed_artists_to_db()
-            self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM followed_artists").fetchone()[0]
+            self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM followed_artists").fetchone()[0]
                              , len(self.spotify.sp.user_artists))
-            self.assertEqual(self.backup.db_conn.execute("SELECT COUNT(*) FROM artists").fetchone()[0]
+            self.assertEqual(self.conn.execute("SELECT COUNT(*) FROM artists").fetchone()[0]
                              , len(self.spotify.sp.user_artists))
-
+    
     def test_insert_tracks_into_db_from_playlist(self):
         thelp.create_env(self.spotify)
         
         tables = ["playlists", "artists", "albums", "tracks", "playlists_tracks"
                   , "tracks_artists", "tracks_albums", "albums_artists"]
-
+        
         # Test adding empty playlist doesn't add anything
         self.backup._insert_tracks_into_db_from_playlist("Pl001")
-        table_lens = [self.backup.db_conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
+        table_lens = [self.conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
         self.assertEqual(any(table_lens), False)
         
         # Test we fail because playlist doesn't exist in 'playlists' table yet
@@ -220,14 +249,14 @@ class TestBackupSpotifyData(unittest.TestCase):
         }
         
         for key, value in expected_table_values.items():
-            self.assertEqual(self.backup.db_conn.execute(f"SELECT * FROM '{key}'").fetchall(), value)
+            self.assertEqual(self.conn.execute(f"SELECT * FROM '{key}'").fetchall(), value)
             
     def test_insert_tracks_into_db_from_playlist_duplicates(self):
         # Test local tracks and duplicates
         thelp.create_env(self.spotify)
         self.backup._insert_many("playlists", [("Pl004", "Fake name", "Fake desc")])   
         self.backup._insert_tracks_into_db_from_playlist("Pl004")
-        self.assertEqual(self.backup.db_conn.execute("SELECT * FROM tracks").fetchall()
+        self.assertEqual(self.conn.execute("SELECT * FROM tracks").fetchall()
             , [  ('Tr001', 'Fake Track 1', 1, 0, 0)
                , ('local_track_Fake Local Track 1', 'Fake Local Track 1', 1, 1, 0)])
 
@@ -238,14 +267,14 @@ class TestBackupSpotifyData(unittest.TestCase):
                   , "tracks_artists", "tracks_albums", "albums_artists"]
 
         # Test adding empty playlist doesn't add anything
-        table_lens = [self.backup.db_conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
+        table_lens = [self.conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
         self.assertEqual(any(table_lens), False)
         
         thelp.create_env(self.spotify)
         self.backup._add_user_playlists_to_db()
         
         # Test adding empty playlist doesn't add anything
-        table_lens = [self.backup.db_conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
+        table_lens = [self.conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
         self.assertEqual(table_lens, [4, 4, 7, 9, 11, 11, 9, 7])
 
     def test_backup_data(self):
@@ -255,20 +284,8 @@ class TestBackupSpotifyData(unittest.TestCase):
         tables = ["playlists", "artists", "albums", "tracks", "followed_artists", "playlists_tracks"
                   , "tracks_artists", "tracks_albums", "albums_artists"]
 
-        table_lens = [self.backup.db_conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
+        table_lens = [self.conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0] for table in tables]
         self.assertEqual(table_lens, [4, 5, 7, 9, 3, 11, 11, 9, 7])
-        
-    def test_exit(self):
-        mock_db_conn = mock.MagicMock()
-        self.backup.db_conn = mock_db_conn
-        self.backup.close()
-        mock_db_conn.close.assert_called_once()
-        self.assertIsNone(self.backup.db_conn)
-    
-    def test_close_when_no_connection(self):
-        self.backup.db_conn = None
-        self.backup.close()
-        self.assertIsNone(self.backup.db_conn)
 
 
 # FIN ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════

--- a/tests/src/proxy/test_Spotipy_Proxy.py
+++ b/tests/src/proxy/test_Spotipy_Proxy.py
@@ -9,6 +9,7 @@
 # Unit tests for all functionality out of 'Spotipy_Proxy.py'.
 # ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 import logging
+import pytest
 import unittest
 from unittest import mock
 
@@ -56,7 +57,7 @@ class TestSpotipyProxy(unittest.TestCase):
         # Test 500 Response Max Retries
         mock_requests_post.return_value.status_code = 500
         mock_requests_post.return_value.json.return_value = {"result": "test"}
-        with self.assertRaises(Exception):
+        with pytest.raises(SystemExit) as exc_info:
             spotipy_proxy.test1()
         self.assertEqual(mock_requests_post.call_count, 3)
         mock_requests_post.reset_mock()
@@ -85,7 +86,7 @@ class TestSpotipyProxy(unittest.TestCase):
 
         # Test Timeout
         spotipy_proxy.overall_timeout = 0
-        with self.assertRaises(Exception):
+        with self.assertRaises(TimeoutError):
             spotipy_proxy.method1274()
         self.assertEqual(mock_requests_post.call_count, 0)
 


### PR DESCRIPTION
Missed adding my decorator to the proxy. 
Also because of how the decorator is setup we have issues with seeing full tracebacks for well known errors. So for a few of those cases I have switched to simply logging an error and then doing a sys.exit(). This way the program still ends since we don't want to continue, but we don't get the traceback printed every time. This works well even for our threading in Implementations.py since sys.exit() exits only on the thread its called on (unless main thread in which all threads get closed but this is good for us anyways).
Also fixed an error out of Backup_Spotify_Data due to atexit not properly closing db connections.