### PR TITLE
BRO-183: Filter on 'the, an, a' in artist creation

### DIFF
--- a/src/Spotify_Features.py
+++ b/src/Spotify_Features.py
@@ -101,10 +101,17 @@ class SpotifyFeatures(LogAllMethods):
     """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''"""
     @gsh.scopes(["user-follow-read"])
     def generate_monthly_release(self) -> None:
+        def sort_key(name: str) -> str:
+            name_upper = name.upper()
+            for prefix in ("THE ", "A ", "AN "):
+                if name_upper.startswith(prefix):
+                    return name_upper[len(prefix):]
+            return name_upper
+
         last_month = datetime.today().replace(day=1) - timedelta(days=1)
         self.mfeatures.generate_artist_release(
             [artist['id'] for artist in sorted(self.spotify.get_user_artists(info=['id', 'name'])
-                                                        , key=lambda ar: ar['name'].upper())]
+                                                ,key=lambda ar: sort_key(ar['name']))]
             , f"Release Radar: {last_month.strftime("%m-%Y")}"
             , f"Releases From All Followed Artists From The Month {last_month.strftime("%m-%Y")}"
             , start_date=datetime(last_month.year, last_month.month, 1)

--- a/tests/src/test_Spotify_Features.py
+++ b/tests/src/test_Spotify_Features.py
@@ -75,12 +75,20 @@ class TestSpotifyFeatures(unittest.TestCase):
     
     def test_generate_monthly_release(self):
         thelp.create_env(self.spotify_features.spotify)
+
+        the_artist = thelp.create_artist('Ar106', "The Artist")
+        a_artist = thelp.create_artist('Ar107', "A Great Artist")
+        an_artist = thelp.create_artist('Ar108', "An Extra Artist")
+
+        self.spotify_features.spotify.sp.artists += [the_artist, a_artist, an_artist]
+        self.spotify_features.spotify.sp.user_artists += [the_artist, a_artist, an_artist]
+
         self.spotify_features.generate_monthly_release()
         last_month = datetime.today().replace(day=1) - timedelta(days=1)
         expected_start_date = datetime(last_month.year, last_month.month, 1)
         expected_end_date = datetime(last_month.year, last_month.month, last_month.day)
         self.mock_misc_features.generate_artist_release.assert_called_once_with(
-                                            ['Ar002', 'Ar003', 'Ar004']
+                                            ['Ar106', 'Ar108', 'Ar002', 'Ar003', 'Ar004', 'Ar107']
                                             , mock.ANY, mock.ANY
                                             , start_date=expected_start_date, end_date=expected_end_date)
     


### PR DESCRIPTION
- "The", "A", "An" shouldn't really determine an artists alphabetical listing. Like "The Maine" should go under "M" not "T"
- Updated unit tests to include these edge cases.